### PR TITLE
Release

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 /node_modules/
+/CHANGELOG.md


### PR DESCRIPTION
semantic-release generates CHANGELOG.md that does not match prettier config.
So just ignore it.